### PR TITLE
GT Dados abertos - Fix(insurance) - versão 1.0.0 para 1.0.1

### DIFF
--- a/swagger-apis/insurances/1.0.1.yml
+++ b/swagger-apis/insurances/1.0.1.yml
@@ -3,7 +3,7 @@ info:
   title: API Seguros - Open Finance Brasil
   description: |
     As APIs descritas neste documento são referentes a API de Seguros da fase OpenInsurance do Open Finance Brasil.
-  version: 1.0.0
+  version: 1.0.1
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'


### PR DESCRIPTION
Corrigindo versão no arquivo swagger-apis/insurances/1.0.1.yml
Foi identificado que no ambiente draft a versão dentro do arquivo swagger está como 1.0.0 e o correto seria 1.0.1
Em produção o arquivo segue normalmente com a versão 1.0.1 conforme nesse link - https://github.com/OpenBanking-Brasil/openapi/blob/main/swagger-apis/insurances/1.0.1.yml