### PR TITLE
Update 3.0.0-beta.1.yml - Ajustes nas nomenclaturas de escopos e Adição de Permissão ausente

### DIFF
--- a/swagger-apis/consents/3.0.0-beta.1.yml
+++ b/swagger-apis/consents/3.0.0-beta.1.yml
@@ -56,20 +56,20 @@ info:
       |       |                      |                               | RESOURCES_READ                                           |                               |
       |-------|----------------------|-------------------------------|----------------------------------------------------------|-------------------------------|
       |       |                      |                               | CREDIT_CARDS_ACCOUNTS_READ                               |                               |
-      |       |                      |                               |----------------------------------------------------------| credit-card-account           |
+      |       |                      |                               |----------------------------------------------------------| credit-cards-accounts         |
       |       | Cartão de Crédito    | Limites                       | CREDIT_CARDS_ACCOUNTS_LIMITS_READ                        |                               |
       |       |                      |                               |----------------------------------------------------------| resources                     |
       |       |                      |                               | RESOURCES_READ                                           |                               |
       |       |----------------------|-------------------------------|----------------------------------------------------------|-------------------------------|
       |       |                      |                               | CREDIT_CARDS_ACCOUNTS_READ                               |                               |
-      |       |                      |                               |----------------------------------------------------------| credit-card-account           |
+      |       |                      |                               |----------------------------------------------------------| credit-cards-accounts         |
       |       | Cartão de Crédito    | Transações                    | CREDIT_CARDS_ACCOUNTS_TRANSACTIONS_READ                  |                               |
       | DADOS |                      |                               |----------------------------------------------------------| resources                     |
       |       |                      |                               | RESOURCES_READ                                           |                               |
       |       |----------------------|-------------------------------|----------------------------------------------------------|-------------------------------|
       |       |                      |                               | CREDIT_CARDS_ACCOUNTS_READ                               |                               |
       |       |                      |                               |----------------------------------------------------------|                               |
-      |       |                      |                               | CREDIT_CARDS_ACCOUNTS_BILLS_READ                         | credit-card-account           |
+      |       |                      |                               | CREDIT_CARDS_ACCOUNTS_BILLS_READ                         | credit-cards-accounts         |
       |       | Cartão de Crédito    | Faturas                       |----------------------------------------------------------|                               |
       |       |                      |                               | CREDIT_CARDS_ACCOUNTS_BILLS_TRANSACTIONS_READ            | resources                     |
       |       |                      |                               |----------------------------------------------------------|                               |
@@ -93,7 +93,7 @@ info:
       |       |                      |                               |----------------------------------------------------------|                               |
       | DADOS | Operações de Crédito | Dados do Contrato             | UNARRANGED_ACCOUNTS_OVERDRAFT_READ                       | unarranged-accounts-overdraft |
       |       |                      |                               |----------------------------------------------------------|                               |
-      |       |                      |                               | UNARRANGED_ACCOUNTS_OVERDRAFT_WARRANTIES_READ            | invouce-financings            |
+      |       |                      |                               | UNARRANGED_ACCOUNTS_OVERDRAFT_WARRANTIES_READ            | invoice-financings            |
       |       |                      |                               |----------------------------------------------------------|                               |
       |       |                      |                               | UNARRANGED_ACCOUNTS_OVERDRAFT_SCHEDULED_INSTALMENTS_READ | resources                     |
       |       |                      |                               |----------------------------------------------------------|                               |
@@ -422,6 +422,7 @@ components:
                   - FUNDS_READ
                   - VARIABLE_INCOMES_READ
                   - TREASURE_TITLES_READ
+                  - EXCHANGES_READ
               minItems: 1
               example:
                 - ACCOUNTS_READ
@@ -570,6 +571,7 @@ components:
                   - FUNDS_READ
                   - VARIABLE_INCOMES_READ
                   - TREASURE_TITLES_READ
+                  - EXCHANGES_READ
               example:
                 - ACCOUNTS_READ
                 - ACCOUNTS_OVERDRAFT_LIMITS_READ


### PR DESCRIPTION
**O que foi feito:** 
- Alguns escopos estávam incorretos, necessitando assim os ajustes feitos nesse commit.  
- A Permissão EXCHANGES_READ estava listada na descrição do swagger, mas não era listada no ENUM de permissions, portanto, foi adicionada.